### PR TITLE
Add Details on GraphQL Pagination in Docs

### DIFF
--- a/docs/04-graphql.md
+++ b/docs/04-graphql.md
@@ -21,19 +21,25 @@ query {
 
 ### Paginated Query
 
-Repository information is a paginated list. You can use `first` and `after` to fetch more data, i.e. `repositories(first: 3)`.
+Repository information is a paginated list. You can use `first` and `after` to fetch more data, i.e. `repositories(first: 3)`. You can find a detailed explanation of the usage and approaches of pagination [here](https://github.com/JefferyHus/graphql-pagination).
 
 #### Organization
 
 ```graphql
 query {
   organization(login: "octokit") {
-    repositories(first: 3) {
+    repositories(first: 3, after: null) {
       nodes {
         id
         name
         description
       }
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      } 
     }
   }
 }
@@ -46,12 +52,18 @@ Query repositories of a user. Change `organisation` with `user` and `login` with
 ```graphql
 query {
   user(login: "aatmmr") {
-    repositories(first: 3) {
+    repositories(first: 3, after: null) {
       nodes {
         id
         name
         description
       }
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      } 
     }
   }
 }
@@ -62,7 +74,7 @@ Fetch more data you are interested in. For example, you can add `url` and `creat
 ```graphql
 query {
   user(login: "aatmmr") {
-    repositories(first: 20) {
+    repositories(first: 20, after: null) {
       nodes {
         id
         name
@@ -70,11 +82,16 @@ query {
         url
         createdAt
       }
+      pageInfo {
+        endCursor
+        startCursor
+        hasNextPage
+        hasPreviousPage
+      } 
     }
   }
 }
 ```
-
 ### Simplify with Variables
 
 Define variable in `query` and is use it in desired place, e.g. `login`.


### PR DESCRIPTION
This pull request updates the GraphQL documentation to include more comprehensive pagination details. The changes primarily focus on enhancing the examples provided in the documentation by including pagination metadata and a reference to a detailed guide on pagination.

Enhancements to GraphQL documentation:

* [`docs/04-graphql.md`](diffhunk://#diff-c934cedead0df6097aa7e24bc965ee200e1b1026f247d48f3b55040d175bc0f5L24-R42): Added a link to a detailed explanation of pagination usage and approaches.
* [`docs/04-graphql.md`](diffhunk://#diff-c934cedead0df6097aa7e24bc965ee200e1b1026f247d48f3b55040d175bc0f5L24-R42): Updated the `organization` query example to include pagination metadata (`endCursor`, `startCursor`, `hasNextPage`, `hasPreviousPage`).
* [`docs/04-graphql.md`](diffhunk://#diff-c934cedead0df6097aa7e24bc965ee200e1b1026f247d48f3b55040d175bc0f5L49-R66): Updated the `user` query example to include pagination metadata (`endCursor`, `startCursor`, `hasNextPage`, `hasPreviousPage`).
* [`docs/04-graphql.md`](diffhunk://#diff-c934cedead0df6097aa7e24bc965ee200e1b1026f247d48f3b55040d175bc0f5L65-L77): Updated the `user` query example with more data fields (`url`, `createdAt`) and included pagination metadata (`endCursor`, `startCursor`, `hasNextPage`, `hasPreviousPage`).